### PR TITLE
fix: restore PWA installability

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
         short_name: 'Meal Guru',
         description: 'Plan meals, build shopping lists, cook step-by-step',
         start_url: '/app/',
-        scope: '/app/',
+        scope: '/',
         id: '/app/',
         display: 'standalone',
         theme_color: '#CF6A43',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,7 +14,7 @@ const { title = "Meal Guru" } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#CF6A43" />
     <title>{title} — Meal Guru</title>
     <ClientRouter />

--- a/src/pages/app/[...path].astro
+++ b/src/pages/app/[...path].astro
@@ -11,7 +11,9 @@ import App from "@/components/app/App";
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#CF6A43" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>Meal Guru</title>
+    <script is:inline src="/registerSW.js"></script>
   </head>
   <body>
     <App client:only="react" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,8 +9,10 @@ export const prerender = true;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#CF6A43" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="description" content="Meal Guru helps you plan your weekly meals, organize shopping lists, and cook step by step — so you spend less time deciding and more time enjoying." />
     <title>Meal Guru</title>
+    <script is:inline src="/registerSW.js"></script>
   </head>
   <body>
     <main class="min-h-screen flex flex-col items-center justify-center px-6 py-16">

--- a/src/pages/oauth/consent.astro
+++ b/src/pages/oauth/consent.astro
@@ -31,7 +31,7 @@ const details = data && "authorization_id" in data ? data : null;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#CF6A43" />
     <title>Authorize — Meal Guru</title>
   </head>


### PR DESCRIPTION
## Problem

Chrome mobile stopped offering "Install app". The built HTML contained **no `<link rel="manifest">` and no service worker registration** on any page — `@vite-pwa/astro` generates `manifest.webmanifest`, `registerSW.js` and `sw.js` into `dist/`, but never injected the tags. With no manifest reachable from the document, Chrome's installability check can't run.

A second issue would have blocked it even after linking: `scope` was `/app/`, which excludes the landing page at `/`, so Chrome ignores the manifest for that document.

## Changes

- `astro.config.mjs`: manifest `scope` `/app/` → `/` (`start_url` stays `/app/`, still in scope)
- `src/pages/index.astro` and `src/pages/app/[...path].astro`: add `<link rel="manifest" href="/manifest.webmanifest">` and `<script is:inline src="/registerSW.js">`
- `src/layouts/Layout.astro`, `src/pages/oauth/consent.astro`: `/site.webmanifest` (404 — no such file in `public/`) → `/manifest.webmanifest`

## Verification

`npm run build` succeeds; `dist/index.html` and the SSR-rendered `/app` template both contain the manifest link and registerSW script, and the emitted manifest has `"scope":"/"`.

Not covered by tests: `tests/e2e/offline.spec.ts` exercises SW offline behavior but nothing asserts installability, which is why the missing tags and the 404 manifest went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)